### PR TITLE
feat: Add additional output for groups-users submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Apache 2 Licensed. See [LICENSE](LICENSE) for full details.
 ## AUTHORS
 
 <!--- Replace repository name -->
-<a href="https://github.com/getindata/REPO_NAME/graphs/contributors">
+<a href="https://github.com/getindata/terraform-google-group-users-data-source/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=getindata/terraform-module-template" />
 </a>
 

--- a/examples/groups-users/.envrc
+++ b/examples/groups-users/.envrc
@@ -1,0 +1,2 @@
+#Override defaults
+command -v dotenv && test -f .env && dotenv

--- a/examples/groups-users/Makefile
+++ b/examples/groups-users/Makefile
@@ -1,0 +1,11 @@
+init:
+	terraform init
+
+plan:
+	terraform plan -out tfplan
+
+apply:
+	terraform apply tfplan
+
+destroy:
+	terraform destroy

--- a/examples/groups-users/README.md
+++ b/examples/groups-users/README.md
@@ -1,0 +1,17 @@
+# Simple Example
+
+```terraform
+module "terraform_module_template" {
+  source  = "../../"
+
+  example_var = "This is a example value."
+}
+```
+
+## Usage
+
+```shell
+terraform init
+terraform plan -out tfplan
+terraform apply tfplan
+```

--- a/examples/groups-users/README.md
+++ b/examples/groups-users/README.md
@@ -1,10 +1,12 @@
-# Simple Example
+# Groups-Users submodule Example
 
 ```terraform
-module "terraform_module_template" {
-  source  = "../../"
-
-  example_var = "This is a example value."
+module "terraform_google_group_users_data_source" {
+  source = "../../modules/groups-users"
+  group_emails = [
+    "group-name@example.com",
+    "another-group-name@example.com",
+  ]
 }
 ```
 

--- a/examples/groups-users/main.tf
+++ b/examples/groups-users/main.tf
@@ -1,0 +1,7 @@
+module "terraform_google_group_users_data_source" {
+  source = "../../modules/groups-users"
+  group_emails = [
+    "group-name@example.com",
+    "another-group-name@example.com",
+  ]
+}

--- a/examples/groups-users/outputs.tf
+++ b/examples/groups-users/outputs.tf
@@ -1,0 +1,4 @@
+output "example_output" {
+  description = "Example output of the module"
+  value       = module.terraform_google_group_users_data_source
+}

--- a/examples/groups-users/providers.tf
+++ b/examples/groups-users/providers.tf
@@ -1,0 +1,2 @@
+provider "google" {
+}

--- a/examples/groups-users/versions.tf
+++ b/examples/groups-users/versions.tf
@@ -1,0 +1,12 @@
+# Example configuration of terraform providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.4"
+    }
+  }
+}

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,10 +1,9 @@
 # Simple Example
 
 ```terraform
-module "terraform_module_template" {
-  source  = "../../"
-
-  example_var = "This is a example value."
+module "terraform_google_group_users_data_source" {
+  source      = "../../"
+  group_email = "group-name@example.com"
 }
 ```
 

--- a/modules/groups-users/README.md
+++ b/modules/groups-users/README.md
@@ -38,6 +38,7 @@ module "groups_users" {
 |------|-------------|
 | <a name="output_group_members"></a> [group\_members](#output\_group\_members) | Map of google group details and its members |
 | <a name="output_users"></a> [users](#output\_users) | Deduplicated map of google group members (users) in format { email => username } |
+| <a name="output_users_groups"></a> [users\_groups](#output\_users\_groups) | Deduplicated map of google group members (users) in format { email => {user\_name = username, groups = list(groups)}} |
 
 ## Providers
 

--- a/modules/groups-users/locals.tf
+++ b/modules/groups-users/locals.tf
@@ -2,10 +2,17 @@ locals {
   # Create map of group names without domain 
   groups = { for group in var.group_emails : split("@", group)[0] => group }
 
-  # Deduplicated user list
-  users_list = distinct(flatten([for group in module.google_group_members : group.users]))
+  # Create a map of users with groups assigned to them
+  users_groups = transpose({ for group, details in module.google_group_members : group => details.users })
 
   # Create a map of users from deduplicated user list to avoid broadcasting of
   # fake changes due to changes in list ordering
-  users_map = { for user in local.users_list : user => split("@", user)[0] }
+  users_map = { for user_email, groups in local.users_groups : user_email => split("@", user_email)[0] }
+
+  # Create a map of user emails, groups and user names assigned to them
+  users_groups_map = { for user_email, groups in local.users_groups : user_email => {
+    user_name = split("@", user_email)[0]
+    groups    = groups
+    }
+  }
 }

--- a/modules/groups-users/outputs.tf
+++ b/modules/groups-users/outputs.tf
@@ -7,3 +7,8 @@ output "users" {
   value       = local.users_map
   description = "Deduplicated map of google group members (users) in format { email => username }"
 }
+
+output "users_groups" {
+  value       = local.users_groups_map
+  description = "Deduplicated map of google group members (users) in format { email => {user_name = username, groups = list(groups)}}"
+}


### PR DESCRIPTION
* Added `users_groups` output that returns `user_name` and `groups` list (with user-group assignments)
* Modified logic for `user-groups` module
* Added separate example for submodule
* Updated documentation